### PR TITLE
Make key mappings customizable for users

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -210,16 +210,17 @@ function! s:map_keys() abort
         endfor
     endfor
 
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<CR>', '<SID>on_accept', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<BS>', '<SID>on_backspace', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<Del>', '<SID>on_delete', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<C-d>', '<SID>on_delete', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<C-c>', '<SID>on_cancel', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<Esc>', '<SID>on_cancel', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<C-n>', '<SID>on_move_next', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<C-j>', '<SID>on_move_next', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<C-p>', '<SID>on_move_previous', s:current)
-    exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', '<C-k>', '<SID>on_move_previous', s:current)
+    let s:mappings = {
+                \ '<Plug>(quickpick_accept)': '<SID>on_accept',
+                \ '<Plug>(quickpick_backspace)': '<SID>on_backspace',
+                \ '<Plug>(quickpick_delete)': '<SID>on_delete',
+                \ '<Plug>(quickpick_cancel)': '<SID>on_cancel',
+                \ '<Plug>(quickpick_move_next)': '<SID>on_move_next',
+                \ '<Plug>(quickpick_move_previous)': '<SID>on_move_previous',
+                \ }
+    for key in keys(s:mappings)
+        exec printf('noremap <silent> <buffer> %s :call %s(%s)<cr>', key, s:mappings[key], s:current)
+    endfor
 endfunction
 
 function! s:map_key(key, func_name, ...) abort

--- a/ftplugin/quickpick.vim
+++ b/ftplugin/quickpick.vim
@@ -1,0 +1,29 @@
+if !hasmapto('<Plug>(quickpick_accept)')
+    nmap <silent> <buffer> <CR> <Plug>(quickpick_accept)
+endif
+
+if !hasmapto('<Plug>(quickpick_backspace)')
+    nmap <silent> <buffer> <BS> <Plug>(quickpick_backspace)
+endif
+
+if !hasmapto('<Plug>(quickpick_delete)')
+    nmap <silent> <buffer> <Del> <Plug>(quickpick_delete)
+    nmap <silent> <buffer> <Del> <Plug>(quickpick_delete)
+endif
+
+if !hasmapto('<Plug>(quickpick_cancel)')
+    nmap <silent> <buffer> <C-c> <Plug>(quickpick_cancel)
+    nmap <silent> <buffer> <Esc> <Plug>(quickpick_cancel)
+endif
+
+if !hasmapto('<Plug>(quickpick_move_next)')
+    nmap <silent> <buffer> <C-n> <Plug>(quickpick_move_next)
+    nmap <silent> <buffer> <C-j> <Plug>(quickpick_move_next)
+endif
+
+if !hasmapto('<Plug>(quickpick_move_previous)')
+    nmap <silent> <buffer> <C-p> <Plug>(quickpick_move_previous)
+    nmap <silent> <buffer> <C-k> <Plug>(quickpick_move_previous)
+endif
+
+" vim: set sw=4 ts=4 sts=4 et tw=78 foldmarker={{{,}}} foldmethod=marker spell:


### PR DESCRIPTION
This PR enable users to customize key mappings in `quickpick` buffer.

E.g. mapping `<C-h>` to backspace.
```
au FileType quickpick nmap <silent> <buffer> <C-h> <Plug>(quickpick_backspace)
```