### PR TITLE
do not call mapclear

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -154,10 +154,7 @@ function! quickpick#close() abort
     autocmd!
   augroup END
 
-  mapclear <buffer>
   exe 'silent! bunload! ' . s:state['promptbufnr']
-
-  mapclear <buffer>
   exe 'silent! bunload! ' . s:state['resultsbufnr']
 
   let s:inputecharpre = 0


### PR DESCRIPTION
This clear non quickpick buffer maps. So skip it and let vim automatically clear the map when the buffer is unloaded