### PR TITLE
Fix position and length for prop_add to handle multi-byte strings

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -249,7 +249,10 @@ function! s:update_items() abort
     let l:i = 0
     for l:line in s:state['highlights']
       for l:pos in l:line
-        call prop_add(l:i + 1, l:pos + 1, { 'length': 1, 'type': 'highlight', 'bufnr': s:state['resultsbufnr'] })
+        let l:cs = split(getbufline(s:state['resultsbufnr'], l:i + 1)[0], '\zs')
+        let l:mpos = strlen(join(l:cs[: l:pos - 1], ''))
+        let l:len =  strlen(l:cs[l:pos])
+        call prop_add(l:i + 1, l:mpos + 1, { 'length': l:len, 'type': 'highlight', 'bufnr': s:state['resultsbufnr'] })
       endfor
       let l:i += 1
     endfor


### PR DESCRIPTION
Result of matchfuzzypos return character-wized position. But prop_add take byte-offset position.

![image](https://user-images.githubusercontent.com/10111/104126595-d8141680-53a0-11eb-8a58-be091acb75bc.png)

This fix convert the character-wized position to byte-offset position.

![image](https://user-images.githubusercontent.com/10111/104126635-14e00d80-53a1-11eb-944e-f931fe6128be.png)
