### PR TITLE
Fix index out of range when no item in result list

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -265,10 +265,11 @@ endfunction
 function! s:on_accept() abort
   if win_gotoid(s:state['resultswinid'])
     let l:index = line('.') - 1 " line is 1 index, list is 0 index
-    if l:index < 0
+    let l:fitems = s:state['fitems']
+    if l:index < 0 || len(l:fitems) <= l:index
       let l:items = []
     else
-      let l:items = [s:state['fitems'][l:index]]
+      let l:items = [l:fitems[l:index]]
     endif
     call win_gotoid(s:state['winid'])
     call s:notify('accept', { 'items': l:items })


### PR DESCRIPTION
This is a port from https://github.com/prabirshrestha/vim-lsp/pull/1119.

When no item in the result list, accepting item by typing `<CR>` causes 'index out of range' error. This PR fixes the bug.

I'm not sure this PR is useful for you. If not, please feel free to close this.