### PR TITLE
add quickpick#results_winid() API to get internal state for customization

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -187,6 +187,10 @@ function! quickpick#busy(busy) abort
   endif
 endfunction
 
+function! quickpick#results_winid() abort
+  return s:state['resultswinid']
+endfunction
+
 function! s:busy_tick(...) abort
   let s:state['busyframe'] = s:state['busyframe'] + 1
   if s:state['busyframe'] >= len(s:state['busyframes'])

--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -188,7 +188,11 @@ function! quickpick#busy(busy) abort
 endfunction
 
 function! quickpick#results_winid() abort
-  return s:state['resultswinid']
+  if exists('s:state')
+    return s:state['resultswinid']
+  else
+    return 0
+  endif
 endfunction
 
 function! s:busy_tick(...) abort


### PR DESCRIPTION
Closes #22.
This is another approach to #22.

By adding this API, users can customize quickpick behavior by accessing to its internal state.

This change is smaller and cleaner than #22 for maintainer. And more flexible for user (since they can get all internal state in vimrc). Downside is user needs to write the logic by themselves.

For example, I confirmed the following configuration enables scroll wrapping.

```vim
function! s:quickpick_move(next) abort
    let winid = quickpick#results_winid()
    if a:next
        let cur = line('.', winid)
        let end = line('$', winid)
        let cmd = cur == end ? 'gg' : 'j'
    else
        let cur = line('.', winid)
        let cmd = cur == 1 ? 'G' : 'k'
    endif
    call win_execute(winid, 'noautocmd normal! ' . cmd)
endfunction

function! s:quickpick_setup() abort
    " Dummy mappings to prevent quickpick from overriding below mappings
    nmap <buffer><expr><Nop> <Plug>(quickpick-move-next)
    nmap <buffer><expr><Nop><Nop> <Plug>(quickpick-move-previous)
    " Wrap scroll to choosei item
    nnoremap <buffer><C-n> :<C-u>call <SID>quickpick_move(1)<CR>
    inoremap <buffer><C-n> <C-o>:call <SID>quickpick_move(1)<CR>
    nnoremap <buffer><C-p> :<C-u>call <SID>quickpick_move(0)<CR>
    inoremap <buffer><C-p> <C-o>:call <SID>quickpick_move(0)<CR>
endfunction

AutocmdFT quickpick-filter call <SID>quickpick_setup()
```