### PR TITLE
Fix flickering on moving item selection

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -63,10 +63,10 @@ function! quickpick#open(opt) abort
   inoremap <buffer><silent> <Plug>(quickpick-cancel) <ESC>:<C-u>call <SID>on_cancel()<CR>
   nnoremap <buffer><silent> <Plug>(quickpick-cancel) :<C-u>call <SID>on_cancel()<CR>
 
-  inoremap <buffer><silent> <Plug>(quickpick-move-next) <ESC>:<C-u>call <SID>on_move_next(1)<CR>
+  inoremap <buffer><silent> <Plug>(quickpick-move-next) <C-o>:<C-u>call <SID>on_move_next(1)<CR>
   nnoremap <buffer><silent> <Plug>(quickpick-move-next) :<C-u>call <SID>on_move_next(0)<CR>
 
-  inoremap <buffer><silent> <Plug>(quickpick-move-previous) <ESC>:<C-u>call <SID>on_move_previous(1)<CR>
+  inoremap <buffer><silent> <Plug>(quickpick-move-previous) <C-o>:<C-u>call <SID>on_move_previous(1)<CR>
   nnoremap <buffer><silent> <Plug>(quickpick-move-previous) :<C-u>call <SID>on_move_previous(0)<CR>
 
   exec printf('setlocal filetype=' . s:state['promptfiletype'])
@@ -293,18 +293,12 @@ endfunction
 function! s:on_move_next(insertmode) abort
   let l:col = col('.')
   call s:win_execute(s:state['resultswinid'], 'normal! j')
-  if a:insertmode
-    call s:win_execute(s:state['promptwinid'], 'startinsert | call setpos(".", [0, 1, ' . (l:col + 1) .', 1])')
-  endif
   call s:notify_selection()
 endfunction
 
 function! s:on_move_previous(insertmode) abort
   let l:col = col('.')
   call s:win_execute(s:state['resultswinid'], 'normal! k')
-  if a:insertmode
-    call s:win_execute(s:state['promptwinid'], 'startinsert | call setpos(".", [0, 1, ' . (l:col + 1) .', 1])')
-  endif
   call s:notify_selection()
 endfunction
 

--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -323,9 +323,9 @@ function! s:notify_selection() abort
     \ 'resultswinid': s:state['resultswinid'],
     \ 'items': l:items,
     \ }
-  call win_gotoid(s:state['winid'])
+  noautocmd call win_gotoid(s:state['winid'])
   call s:notify('selection', l:data)
-  call win_gotoid(l:original_winid)
+  noautocmd call win_gotoid(l:original_winid)
 endfunction
 
 function! s:on_inputchanged() abort


### PR DESCRIPTION
## Problem

Status line flickers when moving item selection in results window by `<C-n>` and `<C-p>` on insert mode.

Here is screencast:

![before](https://user-images.githubusercontent.com/823277/112873216-4fce2380-90fc-11eb-914b-eb9a07755b8a.gif)

Mode changes to 'Normal` for a moment and then back to 'Insert' immediately.

I found two issues in current implementation.

1. quickpick.vim leaves insert mode by `<Esc>` then enters insert mode again by `:startinsert`. But this triggers auto commands on `InsertEnter` and `InsertLeave`. This causes flickering if the current mode is shown in status line.
2. quickpick.vim enters the original window temporarily for notifying 'selection' event. This causes `WinEnter`. This causes flickering if the current buffer name is shown in status line.

## Fix

For 1., using `<C-o>` instead of `<Esc>` in insert mode is better to run normal command in insert mode. `<C-o>` is a dedicated mapping to do that. It does not change mode so flickering does not occur.

For 2., calling `win_gotoid()` with `:noautocmd` fixed this. Basically moving cursor to a window temporarily should be done with `:noautocmd` to avoid side effects.

With this PR, flickering was resolved as follows:

![after](https://user-images.githubusercontent.com/823277/112874071-6de85380-90fd-11eb-979a-980dfb0f3dc1.gif)
