### PR TITLE
Keep existing window sizes when quickpick opens and closes

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -21,6 +21,7 @@ function! quickpick#open(opt) abort
       \ 'maxheight': 10,
       \ 'debounce': 250,
       \ 'filter': 1,
+      \ 'winrestcmd': '',
       \ }, a:opt)
 
   let s:inputecharpre = 0
@@ -28,9 +29,10 @@ function! quickpick#open(opt) abort
 
   let s:state['bufnr'] = bufnr('%')
   let s:state['winid'] = win_getid()
+  let s:state['winrestcmd'] = winrestcmd()
 
   " create result buffer
-  exe printf('keepalt botright 1new %s', s:state['filetype'])
+  exe printf('keepalt botright 3new %s', s:state['filetype'])
   let s:state['resultsbufnr'] = bufnr('%')
   let s:state['resultswinid'] = win_getid()
   if s:has_proptype
@@ -156,6 +158,7 @@ function! quickpick#close() abort
 
   exe 'silent! bunload! ' . s:state['promptbufnr']
   exe 'silent! bunload! ' . s:state['resultsbufnr']
+  exe 'silent! ' . s:state['winrestcmd']
 
   let s:inputecharpre = 0
 


### PR DESCRIPTION
Windows that is not in contact with quickpick windows are resized when the quickpick windows open and close as follows:

https://user-images.githubusercontent.com/9126033/131221051-eba4a83e-4adf-430c-a8f7-5dc0839e1459.mp4

This PR prevents quickpick from resizing the existing windows.
