### PR TITLE
Fix/incorrect restored window sizes

### DIFF
--- a/autoload/quickpick.vim
+++ b/autoload/quickpick.vim
@@ -149,7 +149,7 @@ function! quickpick#close() abort
 
   call quickpick#busy(0)
 
-  call win_gotoid(s:state['bufnr'])
+  call win_gotoid(s:state['winid'])
   call s:notify('close', { 'bufnr': s:state['bufnr'], 'winid': s:state['winid'], 'resultsbufnr': s:state['resultsbufnr'], 'resultswinid': s:state['winid'] })
 
   augroup quickpick


### PR DESCRIPTION
This commit solves https://github.com/prabirshrestha/vim-lsp/issues/1233.

Sorry for the late update. I finally found the above issue is occurring in Neovim.

The result of `winrestcmd()` includes commands also for floating windows in Neovim. Windows sizes are saved before windows of quickpick open, and the floating windows are closed after the cursor moves to a window of quickpick. The number of windows, therefore, changed between when `winrestcmd()` was called and when the result of `winrestcmd()` was executed.

This commit saves window sizes with `getwininfo()` instead of `winrestcmd` and constructs a command to restore  windows sizes excluding popup windows.
